### PR TITLE
Filter resultaten

### DIFF
--- a/src/Rido/MDR/Models/Transfer.php
+++ b/src/Rido/MDR/Models/Transfer.php
@@ -11,6 +11,7 @@ class Transfer extends Model
         'transfer_id',
         'domein',
         'status',
+        'tld',
         'status_melding',
         'datum_invoer',
         'datum_update',
@@ -22,13 +23,17 @@ class Transfer extends Model
     /**
      * @return bool
      */
-    public function get()
+    public function get(array $attributes = [])
     {
-        if ($result = $this->connection->get('transfer_list')) {
-            return $result['items'];
-        }
+        $this->fill($attributes);
 
-        return false;
+        $result = $this->connection->get('transfer_list', [
+            'status' => $this->status,
+            'domein' => $this->domein,
+            'tld'    => $this->tld,
+        ]);
+
+        return $result['items'];
     }
 
     /**


### PR DESCRIPTION
Omdat wij best vaak de verhuizingen aanriepen was de server regelmatig belast met het aantal requests. Hierop heb ik een verbetering geschreven die kan filteren op de resultaten, zo roep je alleen wat nog niet verhuist is bijvoorbeeld.

Voorbeeld:
`// Zonder filter
$transfers = transfers()->get(); 

// Met filter inclusief status
$transfers = transfers()->get( array( 'domein' => 'demo', 'tld' => 'com', 'status' => 'pending' ) ); 

// Met filter exclusief status (hiermee zoekt hij elk mogelijke status op het domein)
$transfers = transfers()->get( array( 'domein' => 'demo', 'tld' => 'com', 'status' => '' ) ); `