### PR TITLE
No items if transfercount is zero

### DIFF
--- a/src/Rido/MDR/Models/Transfer.php
+++ b/src/Rido/MDR/Models/Transfer.php
@@ -32,8 +32,10 @@ class Transfer extends Model
             'domein' => $this->domein,
             'tld'    => $this->tld,
         ]);
-
-        return $result['items'];
+        
+        if( $result['transfercount'] > 0 ) {
+            return $result['items'];
+        }
     }
 
     /**


### PR DESCRIPTION
The get() method can only return items if transfercount has more than zero values.